### PR TITLE
fix LineageOS 14.1 builds

### DIFF
--- a/include/linux/if_packet.h
+++ b/include/linux/if_packet.h
@@ -173,7 +173,7 @@ struct hdr_v1 {
 	 *    you can see which blk[s] is[are] outstanding etc.
 	 * 3. Validate kernel code.
 	 */
-	aligned_u64	seq_num;
+	__aligned_u64	seq_num;
 
 	/*
 	 * ts_last_pkt:


### PR DESCRIPTION
this is the fix Dggrr on xda found for the following error he (and now I) experienced when building LineageOS 14.1. 

```
In file included from external/ebtables/extensions/ebt_pkttype.c:15:
out/target/product/grouper/obj/KERNEL_OBJ/usr/include/linux/if_packet.h:176:2: error: unknown type name 'aligned_u64'
        aligned_u64     seq_num;
```

This fixed the build for him and me, but I have no idea if this is an error any AOSP builders are facing, and if this would have unintended consequences for AOSP builds.